### PR TITLE
Added option to disable health modification globally and per entity

### DIFF
--- a/src/main/java/net/darkhax/damagecontrol/handler/ConfigurationHandler.java
+++ b/src/main/java/net/darkhax/damagecontrol/handler/ConfigurationHandler.java
@@ -19,6 +19,7 @@ public class ConfigurationHandler {
     private static final Map<DamageSource, Float> damageModifiers = new HashMap<>();
 
     public static float healthModifier = 1f;
+    public static boolean healthAllowed = true;
 
     /**
      * An instance of the Configuration object being used.
@@ -49,6 +50,7 @@ public class ConfigurationHandler {
 
         final String category = "GLOBAL_MODIFIERS";
         healthModifier = config.getFloat("GlobalMaxHealthModifier", category, 1f, 0f, 1024f, "The global max health modifier.");
+        healthAllowed = config.getBoolean("AllowHealthModification", category, true, "Whether to allow health modification by the mod. If false, health modifiers will not be applied. Useful for compatibility reasons");
 
         syncConfig();
     }
@@ -88,7 +90,7 @@ public class ConfigurationHandler {
             return entityBaseHealth.get(entityId);
         }
 
-        final float configAmount = config.getFloat("MaxHealth_" + entityId, "MAX_HEALTH", (float) entity.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).getAttributeValue(), 0f, (float) ((RangedAttribute) SharedMonsterAttributes.MAX_HEALTH).maximumValue, "The maximum health value for " + entityId);
+        final float configAmount = config.getFloat("MaxHealth_" + entityId, "MAX_HEALTH", (float) entity.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).getAttributeValue(), -1f, (float) ((RangedAttribute) SharedMonsterAttributes.MAX_HEALTH).maximumValue, "The maximum health value for " + entityId + ". Negative values deactivate health modification for this entity.");
         entityBaseHealth.put(entityId, configAmount);
 
         syncConfig();

--- a/src/main/java/net/darkhax/damagecontrol/handler/DamageHandler.java
+++ b/src/main/java/net/darkhax/damagecontrol/handler/DamageHandler.java
@@ -15,35 +15,40 @@ public class DamageHandler {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onWorldLoad (WorldEvent.Load event) {
-
-        for (final ResourceLocation entityId : EntityList.ENTITY_EGGS.keySet()) {
-
-            final Entity entity = EntityList.createEntityByIDFromName(entityId, event.getWorld());
-
-            if (entity instanceof EntityLivingBase) {
-
-                ConfigurationHandler.getMaxHealth(entityId, (EntityLivingBase) entity);
-            }
-        }
+    	if (ConfigurationHandler.healthAllowed) {
+	        for (final ResourceLocation entityId : EntityList.ENTITY_EGGS.keySet()) {
+	
+	            final Entity entity = EntityList.createEntityByIDFromName(entityId, event.getWorld());
+	
+	            if (entity instanceof EntityLivingBase) {
+	
+	                ConfigurationHandler.getMaxHealth(entityId, (EntityLivingBase) entity);
+	            }
+	        }
+	    }
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onEntityJoinWorld (EntityJoinWorldEvent event) {
-
-        if (event.getEntity() instanceof EntityLivingBase) {
-
-            final EntityLivingBase entity = (EntityLivingBase) event.getEntity();
-            final float currentMaxHealth = (float) entity.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).getAttributeValue();
-            final float modifiedMaxHealth = ConfigurationHandler.getMaxHealth(entity) * ConfigurationHandler.healthModifier;
-
-            if (currentMaxHealth != modifiedMaxHealth) {
-                entity.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(modifiedMaxHealth);
-            }
-
-            if (entity.getHealth() == currentMaxHealth) {
-                entity.setHealth(modifiedMaxHealth);
-            }
-        }
+    	if (ConfigurationHandler.healthAllowed) {
+	        if (event.getEntity() instanceof EntityLivingBase) {
+	
+	            final EntityLivingBase entity = (EntityLivingBase) event.getEntity();
+	            final float modifiedMaxHealth = ConfigurationHandler.getMaxHealth(entity) * ConfigurationHandler.healthModifier;
+	            
+	            if (modifiedMaxHealth >= 0.0f) {
+	            	final float currentMaxHealth = (float) entity.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).getAttributeValue();
+	            	
+		            if (currentMaxHealth != modifiedMaxHealth) {
+		                entity.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(modifiedMaxHealth);
+		            }
+		
+		            if (entity.getHealth() == currentMaxHealth) {
+		                entity.setHealth(modifiedMaxHealth);
+		            }
+	            }
+	        }
+	    }
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)


### PR DESCRIPTION
Hello Darkhax,

I encountered the same issue as in https://github.com/Darkhax-Minecraft/Damage-Control/issues/8 , figured out I could help fixing it !
Changes:
- Added a global boolean option to disable health modification
- Increased the range of the float health modifiers to include values from -1 to 0. Negative values disable health modification for the entity.